### PR TITLE
feat: 确保国家选项按照各个语言的顺序 而不是Unicode

### DIFF
--- a/components/calculator.tsx
+++ b/components/calculator.tsx
@@ -1280,7 +1280,7 @@ const SalaryCalculator = () => {
                   // 确保中国始终排在第一位
                   if (a === 'CN') return -1;
                   if (b === 'CN') return 1;
-                  return getCountryName(a).localeCompare(getCountryName(b));
+                  return new Intl.Collator(['zh', 'ja', 'en']).compare(getCountryName(a), getCountryName(b));
                 }).map(code => (
                   <option key={code} value={code}>
                     {getCountryName(code)} ({pppFactors[code].toFixed(2)})


### PR DESCRIPTION
之前按照unicode排序，中文界面中效果不好。

如果是中文，按照拼音顺序排序。
如果是英文，按照字母顺序排序。
如果是日文，按照Kana排序。


改动后如图：
![Screenshot 2025-04-02 at 8 52 13 PM](https://github.com/user-attachments/assets/7af4f7b6-26c9-4aef-9262-7b95fa97ad40)
![Screenshot 2025-04-02 at 8 52 18 PM](https://github.com/user-attachments/assets/fa2da816-1fda-463d-9dc1-31ddbf9a5b56)
![Screenshot 2025-04-02 at 8 52 23 PM](https://github.com/user-attachments/assets/ba2784ef-1ff1-467c-81cf-d39c632c72e0)
