### PR TITLE
fix: 修复 html2canvas 处理 rem 文字基线的对齐问题

### DIFF
--- a/components/ShareCard.tsx
+++ b/components/ShareCard.tsx
@@ -578,6 +578,11 @@ const ShareCard: React.FC<ShareCardProps> = (props) => {
       // 动态导入html2canvas，确保只在客户端加载
       const html2canvasModule = await import('html2canvas');
       const html2canvas = html2canvasModule.default;
+
+      // 修复 html2canvas 在处理 rem 时文字基线问题
+      const style = document.createElement('style');
+      document.head.appendChild(style);
+      style.sheet?.insertRule('body > div:last-child img { display: inline-block; }');
       
       // 使用html2canvas生成图片
       const canvas = await html2canvas(element, {
@@ -587,6 +592,9 @@ const ShareCard: React.FC<ShareCardProps> = (props) => {
         allowTaint: true,
         logging: false
       });
+
+      // 生成 canvas 后移除临时的 style 标签
+      style.remove();
       
       // 转换为图片并下载
       const image = canvas.toDataURL('image/png');


### PR DESCRIPTION
「下载报告」在生成图像时，文字会有偏移，是由 html2canvs 在处理 rem 时的问题造成的
see https://github.com/niklasvh/html2canvas/issues/2888

before:
![image](https://github.com/user-attachments/assets/6c40fa0a-358d-4181-b2bd-e06cd37acb72)

after:
![工作性价比报告 (2)](https://github.com/user-attachments/assets/34876ccf-4559-471a-a770-9fb89111c939)


